### PR TITLE
Update links to video tutorials on readme page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ on an older Godot 4 version
 
 [Quest Manager API](documentation/Quest_Manager_API.md)
 
-[Video Tutorial pt 1: Setup and Interface](https://youtu.be/9tu-Q-T--mY)
+[Video Tutorial pt 1: Setup and Interface](https://youtu.be/zBJ6NEJTT9s)
 
-[Video Tutorial pt 2: Adding and Completing Quests](https://youtu.be/9tu-Q-T--mY)
+[Video Tutorial pt 2: Adding and Completing Quests](https://youtu.be/JI_LXcY8-Ug)
 
 ## Discord
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ on an older Godot 4 version
 
 [Quest Manager API](documentation/Quest_Manager_API.md)
 
-[Video Tutorial](https://youtu.be/9tu-Q-T--mY)
+[Video Tutorial pt 1: Setup and Interface](https://youtu.be/9tu-Q-T--mY)
+
+[Video Tutorial pt 2: Adding and Completing Quests](https://youtu.be/9tu-Q-T--mY)
 
 ## Discord
 


### PR DESCRIPTION
This pr removes the link to the old video tutorial, which is a year old.

The old link is replaced by links to your two month old videos, part 1 and part 2

Looking forward to get started with your plugin!